### PR TITLE
Feat/update chart add tractusx values

### DIFF
--- a/charts/gh-org-checks/.helmignore
+++ b/charts/gh-org-checks/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# custom values files
+values-*.yaml

--- a/charts/gh-org-checks/Chart.yaml
+++ b/charts/gh-org-checks/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "2022-09-15.33.fe79449"

--- a/charts/gh-org-checks/templates/deployment.yaml
+++ b/charts/gh-org-checks/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
               protocol: TCP
           env:
             - name: GITHUB_ORG_NAME
-              value: "catenax-ng"
+              value: {{ .Values.githubOrgName }}
             - name: GITHUB_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/gh-org-checks/values-tractusx.yaml
+++ b/charts/gh-org-checks/values-tractusx.yaml
@@ -1,0 +1,17 @@
+githubOrgName: "eclipse-tractusx"
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: tractusx-gh-org-checks.core.demo.catena-x.net
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: tls-secret
+      hosts:
+        - tractusx-gh-org-checks.core.demo.catena-x.net

--- a/charts/gh-org-checks/values.yaml
+++ b/charts/gh-org-checks/values.yaml
@@ -1,13 +1,16 @@
 # Default values for gh-org-checks.
 # Declare variables to be passed into your templates.
 
+# The name of the Github organization to scan
+githubOrgName: "catenax-ng"
+
 replicaCount: 2
 
 image:
   repository: ghcr.io/catenax-ng/gh-org-checks
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "2022-09-15.33.fe79449"
 
 nameOverride: ""
 fullnameOverride: ""
@@ -18,7 +21,6 @@ securityContext:
 
 service:
   port: 80
-
 
 ingress:
   enabled: true
@@ -35,6 +37,3 @@ ingress:
     - secretName: tls-secret
       hosts:
         - gh-org-checks.core.demo.catena-x.net
-
-
-


### PR DESCRIPTION
- Update `.helmignore` to skip custom values files
- Remove latest image tag from `Chart.yaml` and `values.yaml` and use a proper image tag available
- Add `githubOrgName` variable to values files to specify whick Gh org to scan
- Add eclipse-tractusx Gh org values file
- Bump chart version to 1.1.0