### PR TITLE
feat: remove archived repos from analysis

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,28 @@
+name: Go build and test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.19.x', '1.20.x' ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,12 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@main
-
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -39,10 +33,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set application version
-        id: app_version
-        run: echo "::set-output name=prefix::$(date +'%Y-%m-%d').${{ github.run_number }}."
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -38,14 +38,14 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Generate docker image tags and labels
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=schedule
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/main.go
+++ b/main.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	orgReport  = data.OrgReports{}
-	testRunner *testrunner.TestRunner
+	orgReport = data.OrgReports{}
 )
 
 func main() {

--- a/pkg/testrunner/TestRunner.go
+++ b/pkg/testrunner/TestRunner.go
@@ -98,6 +98,8 @@ func (runner *TestRunner) PerformRepoChecks() data.OrgReports {
 			}
 		}
 
+		repos = removeArchivedRepos(repos)
+
 		numRepo += len(repos)
 
 		for _, repo := range repos {
@@ -124,4 +126,16 @@ func (runner *TestRunner) PerformRepoChecks() data.OrgReports {
 	orgReport.NumOfRepos = numRepo
 
 	return orgReport
+}
+
+func removeArchivedRepos(repositories []*github.Repository) []*github.Repository {
+	var result []*github.Repository
+
+	for _, repo := range repositories {
+		if *repo.Archived != true {
+			result = append(result, repo)
+		}
+	}
+
+	return result
 }

--- a/pkg/testrunner/TestRunner_test.go
+++ b/pkg/testrunner/TestRunner_test.go
@@ -1,0 +1,55 @@
+package testrunner
+
+import (
+	"github.com/google/go-github/v45/github"
+	"testing"
+)
+
+func Test_listOfOnlyPublicRepositoriesRemainsUnchangedWhenRemovingArchivedOnes(t *testing.T) {
+	repositories := []*github.Repository{
+		{
+			Name:     github.String("just-a-public-example"),
+			Archived: github.Bool(false),
+		},
+		{
+			Name:     github.String("just-another-public-example"),
+			Archived: github.Bool(false),
+		},
+	}
+	initialRepositoryCount := len(repositories)
+
+	repositories = removeArchivedRepos(repositories)
+
+	if len(repositories) != initialRepositoryCount {
+		t.Errorf("expeced length of %v, but got %v", initialRepositoryCount, len(repositories))
+	}
+}
+
+func Test_shouldRemoveArchivedRepositoriesAndKeepPublicOnes(t *testing.T) {
+	repositories := []*github.Repository{
+		{
+			Name:     github.String("just-a-public-example"),
+			Archived: github.Bool(false),
+		},
+		{
+			Name:     github.String("an-archived-repo"),
+			Archived: github.Bool(true),
+		},
+		{
+			Name:     github.String("just-another-public-example"),
+			Archived: github.Bool(false),
+		},
+	}
+
+	repositories = removeArchivedRepos(repositories)
+
+	if len(repositories) != 2 {
+		t.Errorf("expeced length of %v, but got %v", 2, len(repositories))
+	}
+
+	for _, repo := range repositories {
+		if *repo.Archived {
+			t.Errorf("filtered result contains repository marked as archived. Repo name %s", *repo.Name)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new function, that removes repositories that are archived from the list of checked repositories.

This also adds a new workflow, that will do a go build and test on each PR and push to main. It is implemented as a matrix build and will currently run with go version 1.19.x and 1.20.x.


Also added an initial .gitignore and removed an unused variable